### PR TITLE
Support Dolby Cinema (filter) in PatheShowing

### DIFF
--- a/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApi.java
+++ b/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApi.java
@@ -162,7 +162,8 @@ public class PatheApi implements Cinema {
                 !eq(d.isDolbyatmos(), showing.getIsAtmos()) ||
                 !eq(d.isK4(), showing.getIs4k()) ||
                 !eq(d.isLaser(), showing.getIsLaser()) ||
-                !eqBool(d.isDx4(), showing.getIs4dx())
+                !eqBool(d.isDx4(), showing.getIs4dx()) ||
+                !eqBool(d.isDolbycinema(), showing.getIsVision())
                 ){
             LOGGER.debug("The boolean filters failed");
             return false;
@@ -189,14 +190,17 @@ public class PatheApi implements Cinema {
 
         if(showing.getImax() == 1)
             builder.append(" IMAX");
+        if(showing.getIsVision()) {
+            builder.append(" Dolby Cinema");
+        } else if(showing.getIsLaser() == 1) {
+            builder.append(" LASER");
+        }
+        if(showing.getIs4dx())
+            builder.append(" 4DX");
         if(showing.getIs3d() == 1)
             builder.append(" 3D");
         if(showing.getIs4k() == 1)
             builder.append(" 4K");
-        if(showing.getIsLaser() == 1)
-            builder.append(" LASER");
-        if(showing.getIs4dx())
-            builder.append(" 4DX");
 
         builder.append(System.lineSeparator());
         if(showing.getStart() != -1L)

--- a/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheShowing.java
+++ b/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheShowing.java
@@ -54,8 +54,11 @@ public class PatheShowing {
     @JsonProperty
     private Boolean is4dx;
 
-    public PatheShowing(int cinemaId, long movieId, long id, long start, long end, Integer is3d, Integer nl,
-                        Integer imax, Integer ov, Integer hfr, Integer isAtmos, Integer is4k, Integer isLaser, Boolean is4dx) {
+    @JsonProperty
+    private Boolean isVision;
+
+    public PatheShowing(int cinemaId, long movieId, long id, long start, long end, Integer is3d, Integer nl, Integer imax,
+                        Integer ov, Integer hfr, Integer isAtmos, Integer is4k, Integer isLaser, Boolean is4dx, Boolean isVision) {
         this.cinemaId = cinemaId;
         this.movieId = movieId;
         this.id = id;
@@ -70,6 +73,7 @@ public class PatheShowing {
         this.is4k = is4k;
         this.isLaser = isLaser;
         this.is4dx = is4dx;
+        this.isVision = isVision;
     }
 
     public PatheShowing() { }
@@ -165,6 +169,14 @@ public class PatheShowing {
 
     public void setIs4dx(Boolean is4dx) {
         this.is4dx = is4dx;
+    }
+
+    public Boolean getIsVision() {
+        return isVision;
+    }
+
+    public void setIsVision(Boolean isVision) {
+        this.isVision = isVision;
     }
 
     public long getMovieId() {

--- a/src/test/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApiTest.java
+++ b/src/test/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApiTest.java
@@ -121,7 +121,8 @@ public class PatheApiTest {
                 "            \"isAtmos\": 1," +
                 "            \"is4k\": 0," +
                 "            \"isLaser\": 0," +
-                "            \"is4dx\": false" +
+                "            \"is4dx\": false," +
+                "            \"isVision\": false" +
                 "        }" +
                 "    ]" +
                 "}");
@@ -146,14 +147,30 @@ public class PatheApiTest {
     public void testIS4DX() throws ParseException {
         PatheApi api = spy(new PatheApi(new ObjectMapper(), "SOMEKEY", patheCacheRepository, notificationService));
 
-        Watcher watcher = new Watcher("SOMEID", "SOMEUSER", "Star Wars 8 (R'dam Dolby Cinema week 1)", 21432, 1510992000185L, 1513186080310L, new WatcherFilters(
+        Watcher watcher = new Watcher("SOMEID", "SOMEUSER", "Star Wars 8 (R'dam 4DX week 1)", 21432, 1510992000185L, 1513186080310L, new WatcherFilters(
                 "PATHE12",
                 1513353540786L, 1513540800699L, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE,
                 NOPREFERENCE, NO, NOPREFERENCE, NOPREFERENCE
         ));
 
         PatheShowing patheShowing = new PatheShowing(12, 21432, 2382115, UnixTimestampDeserializer.PATHEFORMAT.parse("2017-12-15T21:00:00+01:00").getTime(),
-                UnixTimestampDeserializer.PATHEFORMAT.parse("2017-12-15T23:50:00+01:00").getTime(), 1, 0, 0, 0, 0, 0, 0, 0, true);
+                UnixTimestampDeserializer.PATHEFORMAT.parse("2017-12-15T23:50:00+01:00").getTime(), 1, 0, 0, 0, 0, 0, 0, 0, true, false);
+
+        assertFalse(api.accepts(watcher, patheShowing));
+    }
+
+    @Test
+    public void testISDolbyCinema() throws ParseException {
+        PatheApi api = spy(new PatheApi(new ObjectMapper(), "SOMEKEY", patheCacheRepository, notificationService));
+
+        Watcher watcher = new Watcher("SOMEID", "SOMEUSER", "Star Wars 8 (R'dam Dolby Cinema week 1)", 21432, 1510992000185L, 1513186080310L, new WatcherFilters(
+                "PATHE12",
+                1513353540786L, 1513540800699L, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE, NOPREFERENCE,
+                NOPREFERENCE, NOPREFERENCE, NO, NOPREFERENCE
+        ));
+
+        PatheShowing patheShowing = new PatheShowing(12, 21432, 2382115, UnixTimestampDeserializer.PATHEFORMAT.parse("2017-12-15T21:00:00+01:00").getTime(),
+                UnixTimestampDeserializer.PATHEFORMAT.parse("2017-12-15T23:50:00+01:00").getTime(), 1, 0, 0, 0, 0, 0, 0, 1, false, true);
 
         assertFalse(api.accepts(watcher, patheShowing));
     }


### PR DESCRIPTION
Parentheses triple checked

---

Commit comments:

 - Update PatheShowing response to include `isVision`, which is used to indicate Dolby Cinema showings
 - Special features in the notification message of a showing can now include Dolby Cinema. Experiences are mentioned first, 3D etc. later. Some Dolby Cinema showings have laser set and others do not, so don't mention it to the user at all (because it is always laser projected in Dolby Cinema).
 - Add specific test for Dolby Cinema watcher, similar to 4DX test