### PR TITLE
Bundled notifications

### DIFF
--- a/src/main/java/it/sijmen/movienotifier/model/Notifier.java
+++ b/src/main/java/it/sijmen/movienotifier/model/Notifier.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 
 public interface Notifier extends Model {
 
-    void notify(User recipient, String message) throws IOException;
+    void notify(User recipient, String messageHeader, String messageBody) throws IOException;
 
     @JsonProperty(value="key", access = JsonProperty.Access.READ_ONLY)
     String getId();

--- a/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApi.java
+++ b/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApi.java
@@ -134,7 +134,7 @@ public class PatheApi implements Cinema {
         Collections.sort(matches);
         String body = matches.stream()
                 .sorted()
-                .map(Object::toString)
+                .map(PatheShowing::toMessageString)
                 .collect(Collectors.joining(lineSeparator()));
 
         notificationService.notify(watcher.getUserid(), makeMessageHeader(watcher, matches.size()), body);

--- a/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApi.java
+++ b/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApi.java
@@ -131,24 +131,24 @@ public class PatheApi implements Cinema {
                 matches.add(showing);
             }
         }
-        if(matches.size() > 0) {
-            matches.sort((s1, s2) -> {
-                if(s1.getStart() != -1L && s2.getStart() != -1L) {
-                    return Long.compare(s1.getStart(), s2.getStart());
-                } else if(s1.getStart() != -1L) {
-                    return -1;
-                } else { // s2.getStart() != -1L
-                    return 1;
-                }
-            });
-            StringBuilder body = new StringBuilder(System.lineSeparator());
-            for(PatheShowing match : matches) {
-                body.append(makeMessageBody(match));
-            }
-            LOGGER.trace("Notifying user about {} matches for watcher", matches.size());
+        if(matches.size() == 0)
+            return;
 
-            notificationService.notify(watcher.getUserid(), makeMessageHeader(watcher, matches.size()), body.toString());
-        }
+        LOGGER.trace("Notifying user about {} matches for watcher", matches.size());
+
+        matches.sort((s1, s2) -> {
+            if(s1.getStart() == -1L)
+                return 1;
+            if(s2.getStart() == -1L)
+                return -1;
+            return Long.compare(s1.getStart(), s2.getStart());
+        });
+        StringBuilder body = new StringBuilder(System.lineSeparator());
+        for(PatheShowing match : matches)
+            body.append(makeMessageBody(match));
+
+        notificationService.notify(watcher.getUserid(), makeMessageHeader(watcher, matches.size()), body.toString());
+
     }
 
     public boolean accepts(Watcher watcher, PatheShowing showing){
@@ -203,13 +203,11 @@ public class PatheApi implements Cinema {
     }
 
     private String makeMessageHeader(Watcher watcher, int matches){
-        StringBuilder builder = new StringBuilder(watcher.getName());
-        builder.append(System.lineSeparator())
-                .append("+")
-                .append(matches)
-                .append(" matches");
-
-        return builder.toString();
+        return watcher.getName() +
+                System.lineSeparator() +
+                "+" +
+                matches +
+                " matches";
     }
 
     private String makeMessageBody(PatheShowing showing) {

--- a/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheShowing.java
+++ b/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheShowing.java
@@ -225,32 +225,32 @@ public class PatheShowing implements Comparable<PatheShowing> {
     private static final SimpleDateFormat format1 = new SimpleDateFormat("EEE d MMMM HH:mm");
     private static final SimpleDateFormat format2 = new SimpleDateFormat("HH:mm");
 
-    public String toString(PatheShowing showing) {
+    public String toMessageString() {
         StringBuilder builder = new StringBuilder();
 
-        if(showing.getStart() != -1L)
-            builder.append(format1.format(new Date(showing.getStart()))).append(" - ")
-                    .append(format2.format(new Date(showing.getEnd())))
+        if(getStart() != -1L)
+            builder.append(format1.format(new Date(getStart()))).append(" - ")
+                    .append(format2.format(new Date(getEnd())))
                     .append(", ");
 
-        if(showing.getImax() == 1)
+        if(getImax() == 1)
             builder.append(" IMAX");
 
-        if(showing.getIsVision())
+        if(getIsVision())
             builder.append(" Dolby Cinema");
-        else if(showing.getIsLaser() == 1)
+        else if(getIsLaser() == 1)
             builder.append(" LASER");
 
-        if(showing.getIs4dx())
+        if(getIs4dx())
             builder.append(" 4DX");
-        if(showing.getIs4k() == 1)
+        if(getIs4k() == 1)
             builder.append(" 4K");
-        if(showing.getIs3d() == 1)
+        if(getIs3d() == 1)
             builder.append(" 3D, ");
         else
             builder.append(" 2D, ");
 
-        builder.append("https://www.pathe.nl/tickets/start/").append(showing.getId());
+        builder.append("https://www.pathe.nl/tickets/start/").append(getId());
 
         return builder.toString();
     }

--- a/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheShowing.java
+++ b/src/main/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheShowing.java
@@ -4,11 +4,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import it.sijmen.movienotifier.model.serialization.UnixTimestampDeserializer;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PatheShowing {
+public class PatheShowing implements Comparable<PatheShowing> {
 
     @JsonProperty
     private int cinemaId;
@@ -216,5 +220,47 @@ public class PatheShowing {
     @Override
     public int hashCode() {
         return (int) (getId() ^ (getId() >>> 32));
+    }
+
+    private static final SimpleDateFormat format1 = new SimpleDateFormat("EEE d MMMM HH:mm");
+    private static final SimpleDateFormat format2 = new SimpleDateFormat("HH:mm");
+
+    public String toString(PatheShowing showing) {
+        StringBuilder builder = new StringBuilder();
+
+        if(showing.getStart() != -1L)
+            builder.append(format1.format(new Date(showing.getStart()))).append(" - ")
+                    .append(format2.format(new Date(showing.getEnd())))
+                    .append(", ");
+
+        if(showing.getImax() == 1)
+            builder.append(" IMAX");
+
+        if(showing.getIsVision())
+            builder.append(" Dolby Cinema");
+        else if(showing.getIsLaser() == 1)
+            builder.append(" LASER");
+
+        if(showing.getIs4dx())
+            builder.append(" 4DX");
+        if(showing.getIs4k() == 1)
+            builder.append(" 4K");
+        if(showing.getIs3d() == 1)
+            builder.append(" 3D, ");
+        else
+            builder.append(" 2D, ");
+
+        builder.append("https://www.pathe.nl/tickets/start/").append(showing.getId());
+
+        return builder.toString();
+    }
+
+    @Override
+    public int compareTo(@NotNull PatheShowing o) {
+        if (this.getStart() == -1)
+            return 1;
+        if (o.getStart() == -1)
+            return -1;
+        return Long.compare(this.getStart(), o.getStart());
     }
 }

--- a/src/main/java/it/sijmen/movienotifier/service/notification/NotificationService.java
+++ b/src/main/java/it/sijmen/movienotifier/service/notification/NotificationService.java
@@ -37,27 +37,27 @@ public class NotificationService {
         );
     }
 
-    public void notify(String userId, String message) {
+    public void notify(String userId, String messageHeader, String messageBody) {
         User user = userRepository.getFirstByUuid(userId);
         if(user == null){
             LOGGER.error("Could not find " + userId + " while this user has enabled watchers");
             return;
         }
         if(user.getEnabledNotifications() == null || user.getEnabledNotifications().isEmpty()){
-            LOGGER.error("Could not notify user {} because no notification types are enabled. message: {}", user.getId(), message);
+            LOGGER.error("Could not notify user {} because no notification types are enabled. message: {} {}",user.getId(), messageHeader, messageBody);
             return;
         }
         user.getEnabledNotifications().forEach(
-                t -> notify(user, message, t)
+                t -> notify(user, messageHeader, messageBody, t)
         );
     }
 
-    private void notify(User user, String message, String notificationType) {
+    private void notify(User user, String messageHeader, String messageBody, String notificationType) {
         Notifier notifier = getNotifier(notificationType);
         try {
-            notifier.notify(user, message);
+            notifier.notify(user, messageHeader, messageBody);
         } catch (Exception e) {
-            LOGGER.error("Notification failed to user {} with message {}", user.getId(), message, e);
+            LOGGER.error("Notification failed to user {} with message {} {}", user.getId(), messageHeader, messageBody, e);
         }
     }
 }

--- a/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/FBMessengerNotifier.java
+++ b/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/FBMessengerNotifier.java
@@ -35,9 +35,9 @@ public class FBMessengerNotifier implements Notifier {
     }
 
     @Override
-    public void notify(User recipient, String message) throws IOException {
+    public void notify(User recipient, String messageHeader, String messageBody) throws IOException {
         PhoneMessageRecipient phoneReceiver = new PhoneMessageRecipient(recipient.getPhonenumber());
-        Message simpleTextMessage = new Message(message);
+        Message simpleTextMessage = new Message(messageHeader + System.lineSeparator() + messageBody);
 
         SendResponse resp = pageClient.publish("me/messages", SendResponse.class,
                 Parameter.with("recipient", phoneReceiver),

--- a/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/FBMessengerNotifier.java
+++ b/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/FBMessengerNotifier.java
@@ -37,7 +37,7 @@ public class FBMessengerNotifier implements Notifier {
     @Override
     public void notify(User recipient, String messageHeader, String messageBody) throws IOException {
         PhoneMessageRecipient phoneReceiver = new PhoneMessageRecipient(recipient.getPhonenumber());
-        Message simpleTextMessage = new Message(messageHeader + System.lineSeparator() + messageBody);
+        Message simpleTextMessage = new Message(messageHeader + System.lineSeparator() + System.lineSeparator() + messageBody);
 
         SendResponse resp = pageClient.publish("me/messages", SendResponse.class,
                 Parameter.with("recipient", phoneReceiver),

--- a/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/MailNotifier.java
+++ b/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/MailNotifier.java
@@ -41,7 +41,7 @@ public class MailNotifier implements Notifier {
         Response response = Mail.using(mailgunConfig)
                 .to(recipient.getEmail())
                 .subject(getTitle(messageHeader))
-                .text(messageHeader + System.lineSeparator() + messageBody)
+                .text(messageHeader + System.lineSeparator() + System.lineSeparator() + messageBody)
                 .build()
                 .send();
         if(!response.isOk())

--- a/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/MailNotifier.java
+++ b/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/MailNotifier.java
@@ -37,17 +37,17 @@ public class MailNotifier implements Notifier {
     }
 
     @Override
-    public void notify(User recipient, String message) throws IOException {
+    public void notify(User recipient, String messageHeader, String messageBody) throws IOException {
         Response response = Mail.using(mailgunConfig)
                 .to(recipient.getEmail())
-                .subject(getTitle(message))
-                .text(message)
+                .subject(getTitle(messageHeader))
+                .text(messageHeader + System.lineSeparator() + messageBody)
                 .build()
                 .send();
         if(!response.isOk())
             throw new IOException("Mailgun returned not ok. Code: " + response.responseCode()
                     + ". Message: " + response.responseMessage());
-        LOGGER.trace("Sent mail message through mailgun to {}. Message: {}", recipient.getEmail(), message);
+        LOGGER.trace("Sent mail message through mailgun to {}. Message: {} {}", recipient.getEmail(), messageHeader, messageBody);
     }
 
     private String getTitle(String message) {

--- a/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/SMSNotifier.java
+++ b/src/main/java/it/sijmen/movienotifier/service/notification/notifiers/SMSNotifier.java
@@ -44,7 +44,7 @@ public class SMSNotifier implements Notifier {
     }
 
     @Override
-    public void notify(User recipient, String message) throws IOException {
+    public void notify(User recipient, String messageHeader, String messageBody) throws IOException {
         Map<String, MessageAttributeValue> smsAttributes = new HashMap<>();
         smsAttributes.put("AWS.SNS.SMS.MaxPrice", new MessageAttributeValue()
                 .withStringValue("0.25")
@@ -52,13 +52,13 @@ public class SMSNotifier implements Notifier {
 
         try{
             snsClient.publish(new PublishRequest()
-                    .withMessage(message)
+                    .withMessage(messageHeader)
                     .withPhoneNumber(recipient.getPhonenumber())
                     .withMessageAttributes(smsAttributes));
         }catch (Exception e){
             throw new IOException("Could not send sms message. Error " + e.getMessage(), e);
         }
-        LOGGER.trace("Sent sms notification trough AWS SNS to {}. Message: {}" + recipient.getPhonenumber(), message);
+        LOGGER.trace("Sent sms notification trough AWS SNS to {}. Message: {}" + recipient.getPhonenumber(), messageHeader);
     }
 
     @Override

--- a/src/test/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApiTest.java
+++ b/src/test/java/it/sijmen/movienotifier/service/cinemas/pathe/PatheApiTest.java
@@ -140,7 +140,7 @@ public class PatheApiTest {
                 )
         ));
 
-        verify(notificationService, times(fired ? 1 : 0)).notify(eq("SOMEUSER"), any());
+        verify(notificationService, times(fired ? 1 : 0)).notify(eq("SOMEUSER"), any(), any());
     }
 
     @Test


### PR DESCRIPTION
To prevent too many notifications and delays in sending messages, bundle all new notifications to be sent per watcher into one message. 

 - Send only one notification per matcher for new matches found
 - Introduce message header, for use in short messages (such as SMS)
 - Explicitly mention 2D as a showing feature, if not 3D

In order to keep the message useful, a total count of new matches is added and results are sorted by showing start time (ascending).

Example of  a full message:
```
⛏️🕷️🕸️ Tomb Raider
+7 matches

Thu 15 March 18:00 - 20:18, IMAX 3D, https://www.pathe.nl/tickets/start/2497948
Thu 15 March 21:00 - 23:18, IMAX 3D, https://www.pathe.nl/tickets/start/2497947
Fri 16 March 10:00 - 12:18, IMAX 3D, https://www.pathe.nl/tickets/start/2497979
Fri 16 March 13:00 - 15:18, IMAX 3D, https://www.pathe.nl/tickets/start/2497978
Fri 16 March 16:00 - 18:18, IMAX 3D, https://www.pathe.nl/tickets/start/2497977
Fri 16 March 19:00 - 21:18, IMAX 3D, https://www.pathe.nl/tickets/start/2497976
Fri 16 March 20:45 - 22:58, 2D, https://www.pathe.nl/tickets/start/2500554
```