### PR TITLE
Update WatcherFilters for experiences

### DIFF
--- a/docs/Api Specifications.yaml
+++ b/docs/Api Specifications.yaml
@@ -451,6 +451,7 @@ definitions:
           - 4k
           - laser
           - 4dx
+          - screenx
           - dolbycinema
           - dolbyatmos
         properties:
@@ -504,6 +505,10 @@ definitions:
             type: string
             enum: [yes, no, no-preference]
             description: whether or not the showing is in 4DX seats
+          screenx:
+            type: string
+            enum: [yes, no, no-preference]
+            description: whether or not the showing uses ScreenX
           dolbycinema:
             type: string
             enum: [yes, no, no-preference]
@@ -511,7 +516,7 @@ definitions:
           dolbyatmos:
             type: string
             enum: [yes, no, no-preference]
-            description: whether or not the showing is in dolbey atmos
+            description: whether or not the showing is in dolby atmos
   Cinema:
     type: object
     properties:

--- a/docs/Api Specifications.yaml
+++ b/docs/Api Specifications.yaml
@@ -454,6 +454,7 @@ definitions:
           - screenx
           - dolbycinema
           - dolbyatmos
+          - regularshowing
         properties:
           startafter:
             title: Showing must start after this timestamp
@@ -517,6 +518,10 @@ definitions:
             type: string
             enum: [yes, no, no-preference]
             description: whether or not the showing is in dolby atmos
+          regularshowing:
+            type: string
+            enum: [yes, no, no-preference]
+            description: whether or not the showing is a ‘regular’ experience / not a premium experience (IMAX, Dolby Cinema, 4DX or ScreenX)
   Cinema:
     type: object
     properties:

--- a/docs/System Specifications.md
+++ b/docs/System Specifications.md
@@ -57,6 +57,7 @@ Users can register watchers. A watcher looks like this:
         "screenx": "no",
         "dolbycinema": "no",
         "dolbyatmos": "no-preference",
+        "regularshowing": "no-preference",
         "3d": "no-preference",
         "4k": "no-preference"
     }
@@ -84,6 +85,7 @@ The following other parameters are supported:
 * `screenx` Showing with ScreenX Experience
 * `dolbycinema` Showing with Dolby Cinema audio and display 
 * `dolbyatmos` Showing with Dolby Atmos audio
+* `regularshowing` Showing not in any of the premium experiences (IMAX, Dolby Cinema, 4DX or ScreenX)
 * `3d` Showing in 3D
 * `4k` Showing in 4K resolution
 

--- a/docs/System Specifications.md
+++ b/docs/System Specifications.md
@@ -54,6 +54,7 @@ Users can register watchers. A watcher looks like this:
         "hfr": "no",
         "laser": "yes",
         "4dx": "no",
+        "screenx": "no",
         "dolbycinema": "no",
         "dolbyatmos": "no-preference",
         "3d": "no-preference",
@@ -80,6 +81,7 @@ The following other parameters are supported:
 * `hfr` Showing with High Frame Rate
 * `laser` Showing with Laser projector
 * `4dx` Showing with 4DX Experience
+* `screenx` Showing with ScreenX Experience
 * `dolbycinema` Showing with Dolby Cinema audio and display 
 * `dolbyatmos` Showing with Dolby Atmos audio
 * `3d` Showing in 3D

--- a/src/main/java/it/sijmen/movienotifier/model/WatcherFilters.java
+++ b/src/main/java/it/sijmen/movienotifier/model/WatcherFilters.java
@@ -49,6 +49,8 @@ public class WatcherFilters implements Model {
 
   @NotNull @JsonProperty private FilterOption dolbyatmos;
 
+  @NotNull @JsonProperty private FilterOption regularshowing;
+
   public WatcherFilters(
       int cinemaid,
       long startafter,
@@ -63,7 +65,8 @@ public class WatcherFilters implements Model {
       FilterOption dx4,
       FilterOption screenx,
       FilterOption dolbycinema,
-      FilterOption dolbyatmos) {
+      FilterOption dolbyatmos,
+      FilterOption regularshowing) {
     this.cinemaid = cinemaid;
     this.startafter = startafter;
     this.startbefore = startbefore;
@@ -78,6 +81,7 @@ public class WatcherFilters implements Model {
     this.screenx = screenx;
     this.dolbycinema = dolbycinema;
     this.dolbyatmos = dolbyatmos;
+    this.regularshowing = regularshowing;
   }
 
   public WatcherFilters() {}
@@ -97,6 +101,7 @@ public class WatcherFilters implements Model {
     this.screenx = filters.screenx;
     this.dolbycinema = filters.dolbycinema;
     this.dolbyatmos = filters.dolbyatmos;
+    this.regularshowing = filters.regularshowing;
   }
 
   @AssertTrue(message = "must be before than the startbefore")
@@ -202,6 +207,14 @@ public class WatcherFilters implements Model {
     this.dolbyatmos = dolbyatmos;
   }
 
+  public FilterOption isRegularshowing() {
+    return regularshowing;
+  }
+
+  public void setRegularshowing(FilterOption regularshowing) {
+    this.regularshowing = regularshowing;
+  }
+
   public void setStartbefore(long startbefore) {
     this.startbefore = startbefore;
   }
@@ -258,6 +271,8 @@ public class WatcherFilters implements Model {
         + dolbycinema
         + ", dolbyatmos="
         + dolbyatmos
+        + ", regularshowing="
+        + regularshowing
         + '}';
   }
 }

--- a/src/main/java/it/sijmen/movienotifier/model/WatcherFilters.java
+++ b/src/main/java/it/sijmen/movienotifier/model/WatcherFilters.java
@@ -43,6 +43,8 @@ public class WatcherFilters implements Model {
   @JsonProperty("4dx")
   private FilterOption dx4;
 
+  @NotNull @JsonProperty private FilterOption screenx;
+
   @NotNull @JsonProperty private FilterOption dolbycinema;
 
   @NotNull @JsonProperty private FilterOption dolbyatmos;
@@ -59,6 +61,7 @@ public class WatcherFilters implements Model {
       FilterOption k4,
       FilterOption laser,
       FilterOption dx4,
+      FilterOption screenx,
       FilterOption dolbycinema,
       FilterOption dolbyatmos) {
     this.cinemaid = cinemaid;
@@ -72,6 +75,7 @@ public class WatcherFilters implements Model {
     this.k4 = k4;
     this.laser = laser;
     this.dx4 = dx4;
+    this.screenx = screenx;
     this.dolbycinema = dolbycinema;
     this.dolbyatmos = dolbyatmos;
   }
@@ -90,6 +94,7 @@ public class WatcherFilters implements Model {
     this.k4 = filters.k4;
     this.laser = filters.laser;
     this.dx4 = filters.dx4;
+    this.screenx = filters.screenx;
     this.dolbycinema = filters.dolbycinema;
     this.dolbyatmos = filters.dolbyatmos;
   }
@@ -173,6 +178,14 @@ public class WatcherFilters implements Model {
     this.dx4 = dx4;
   }
 
+  public FilterOption isScreenx() {
+    return screenx;
+  }
+
+  public void setScreenx(FilterOption screenx) {
+    this.screenx = screenx;
+  }
+
   public FilterOption isDolbycinema() {
     return dolbycinema;
   }
@@ -239,6 +252,8 @@ public class WatcherFilters implements Model {
         + laser
         + ", dx4="
         + dx4
+        + ", screenx="
+        + screenx
         + ", dolbycinema="
         + dolbycinema
         + ", dolbyatmos="

--- a/src/main/java/it/sijmen/movienotifier/service/pathe/PatheApi.java
+++ b/src/main/java/it/sijmen/movienotifier/service/pathe/PatheApi.java
@@ -159,6 +159,7 @@ public class PatheApi {
         && accepts(d.isHfr(), toBool(showing.getHfr()))
         && accepts(d.isK4(), toBool(showing.getIs4k()))
         && accepts(d.isDx4(), showing.getIs4dx())
+        && accepts(d.isScreenx(), showing.getIsScreenx())
         && accepts(d.isDolbycinema(), showing.getIsVision())
         &&
 

--- a/src/main/java/it/sijmen/movienotifier/service/pathe/PatheApi.java
+++ b/src/main/java/it/sijmen/movienotifier/service/pathe/PatheApi.java
@@ -181,7 +181,18 @@ public class PatheApi {
             d.isLaser(),
             toBool(showing.getIsLaser()),
             showing.getIsVision(),
-            (showing.getImax() == 1 && CinemaService.hasLaserImax(showing.getCinemaId())));
+            (showing.getImax() == 1 && CinemaService.hasLaserImax(showing.getCinemaId())))
+        &&
+
+        /*
+         * A showing is considered 'regular' when it is not any premium experience
+         */
+        acceptsAll(
+            d.isRegularshowing(),
+            !toBool(showing.getImax()),
+            !showing.getIsVision(),
+            !showing.getIs4dx(),
+            !showing.getIsScreenx());
   }
 
   private Boolean toBool(Integer i) {
@@ -209,6 +220,34 @@ public class PatheApi {
       }
       if (b) {
         result = true;
+      }
+    }
+
+    if (option == YES) {
+      return result;
+    }
+
+    return !result;
+  }
+
+  /**
+   * If option is NOPREFERENCE, always return true If one of the value is null, return true If
+   * option is YES, all value's are and'ed: (A && B && C ...) If option is NO, all values are
+   * inverse and'ed: !(A && B && C ...)
+   */
+  private boolean acceptsAll(FilterOption option, Boolean... value) {
+    if (option == NOPREFERENCE) {
+      return true;
+    }
+    boolean result = true;
+
+    for (Boolean b : value) {
+      // if there is missing data, always return true
+      if (b == null) {
+        return true;
+      }
+      if (!b) {
+        result = false;
       }
     }
 

--- a/src/main/java/it/sijmen/movienotifier/service/pathe/api/PatheShowing.java
+++ b/src/main/java/it/sijmen/movienotifier/service/pathe/api/PatheShowing.java
@@ -46,6 +46,8 @@ public class PatheShowing implements Comparable<PatheShowing> {
 
   @JsonProperty private Boolean is4dx;
 
+  @JsonProperty private Boolean isScreenx;
+
   @JsonProperty private Boolean isVision;
 
   public PatheShowing(
@@ -63,6 +65,7 @@ public class PatheShowing implements Comparable<PatheShowing> {
       Integer is4k,
       Integer isLaser,
       Boolean is4dx,
+      Boolean isScreenx,
       Boolean isVision) {
     this.cinemaId = cinemaId;
     this.movieId = movieId;
@@ -78,6 +81,7 @@ public class PatheShowing implements Comparable<PatheShowing> {
     this.is4k = is4k;
     this.isLaser = isLaser;
     this.is4dx = is4dx;
+    this.isScreenx = isScreenx;
     this.isVision = isVision;
   }
 
@@ -176,6 +180,14 @@ public class PatheShowing implements Comparable<PatheShowing> {
     this.is4dx = is4dx;
   }
 
+  public Boolean getIsScreenx() {
+    return isScreenx;
+  }
+
+  public void setIsScreenx(Boolean isScreenx) {
+    this.isScreenx = isScreenx;
+  }
+
   public Boolean getIsVision() {
     return isVision;
   }
@@ -252,6 +264,7 @@ public class PatheShowing implements Comparable<PatheShowing> {
     }
 
     if (getIs4dx()) builder.append("4DX ");
+    if (getIsScreenx()) builder.append("ScreenX ");
     if (getIs4k() == 1) builder.append("4K ");
     if (getIs3d() == 1) builder.append("3D");
     else builder.append("2D");

--- a/src/test/java/it/sijmen/movienotifier/api/WatcherTestBase.java
+++ b/src/test/java/it/sijmen/movienotifier/api/WatcherTestBase.java
@@ -40,7 +40,8 @@ abstract class WatcherTestBase extends UserTestBase {
                 NO,
                 NO,
                 NOPREFERENCE,
-                YES));
+                YES,
+                NOPREFERENCE));
   }
 
   @After
@@ -76,6 +77,7 @@ abstract class WatcherTestBase extends UserTestBase {
         d.isScreenx(),
         d.isDolbycinema(),
         d.isDolbyatmos(),
+        d.isRegularshowing(),
         d.getCinemaid(),
         d.getStartafter(),
         d.getStartbefore());
@@ -93,6 +95,7 @@ abstract class WatcherTestBase extends UserTestBase {
       FilterOption screenx,
       FilterOption dolbycinema,
       FilterOption dolbyatmos,
+      FilterOption regularshowing,
       int cinemaid,
       long startafter,
       long startbefore) {
@@ -109,6 +112,7 @@ abstract class WatcherTestBase extends UserTestBase {
     if (screenx != null) items.add("\"screenx\": \"" + screenx + "\"");
     if (dolbycinema != null) items.add("\"dolbycinema\": \"" + dolbycinema + "\"");
     if (dolbyatmos != null) items.add("\"dolbyatmos\": \"" + dolbyatmos + "\"");
+    if (regularshowing != null) items.add("\"regularshowing\": \"" + regularshowing + "\"");
     if (startafter != -1) items.add("\"startafter\": \"" + startafter + "\"");
     if (startbefore != -1) items.add("\"startbefore\": \"" + startbefore + "\"");
 

--- a/src/test/java/it/sijmen/movienotifier/api/WatcherTestBase.java
+++ b/src/test/java/it/sijmen/movienotifier/api/WatcherTestBase.java
@@ -1,8 +1,6 @@
 package it.sijmen.movienotifier.api;
 
-import static it.sijmen.movienotifier.model.FilterOption.NO;
-import static it.sijmen.movienotifier.model.FilterOption.NOPREFERENCE;
-import static it.sijmen.movienotifier.model.FilterOption.YES;
+import static it.sijmen.movienotifier.model.FilterOption.*;
 import static org.mockito.Mockito.when;
 
 import it.sijmen.movienotifier.model.FilterOption;
@@ -40,6 +38,7 @@ abstract class WatcherTestBase extends UserTestBase {
                 NO,
                 NOPREFERENCE,
                 NO,
+                NO,
                 NOPREFERENCE,
                 YES));
   }
@@ -74,6 +73,7 @@ abstract class WatcherTestBase extends UserTestBase {
         d.isK4(),
         d.isLaser(),
         d.isDx4(),
+        d.isScreenx(),
         d.isDolbycinema(),
         d.isDolbyatmos(),
         d.getCinemaid(),
@@ -90,6 +90,7 @@ abstract class WatcherTestBase extends UserTestBase {
       FilterOption k4,
       FilterOption laser,
       FilterOption dx4,
+      FilterOption screenx,
       FilterOption dolbycinema,
       FilterOption dolbyatmos,
       int cinemaid,
@@ -105,6 +106,7 @@ abstract class WatcherTestBase extends UserTestBase {
     if (k4 != null) items.add("\"4k\": \"" + k4 + "\"");
     if (laser != null) items.add("\"laser\": \"" + laser + "\"");
     if (dx4 != null) items.add("\"4dx\": \"" + dx4 + "\"");
+    if (screenx != null) items.add("\"screenx\": \"" + screenx + "\"");
     if (dolbycinema != null) items.add("\"dolbycinema\": \"" + dolbycinema + "\"");
     if (dolbyatmos != null) items.add("\"dolbyatmos\": \"" + dolbyatmos + "\"");
     if (startafter != -1) items.add("\"startafter\": \"" + startafter + "\"");

--- a/src/test/java/it/sijmen/movienotifier/integrationtests/WatcherIT.java
+++ b/src/test/java/it/sijmen/movienotifier/integrationtests/WatcherIT.java
@@ -131,7 +131,8 @@ class WatcherIT {
           "3d",
           "4k",
           "4dx",
-          "screenx"
+          "screenx",
+          "regularshowing"
         };
     for (String o : opts) {
       if (includeNulls && r.nextBoolean()) continue;

--- a/src/test/java/it/sijmen/movienotifier/integrationtests/WatcherIT.java
+++ b/src/test/java/it/sijmen/movienotifier/integrationtests/WatcherIT.java
@@ -1,11 +1,12 @@
 package it.sijmen.movienotifier.integrationtests;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.*;
 
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.slf4j.Logger;
@@ -120,7 +121,17 @@ class WatcherIT {
     out.put("startbefore", r.nextInt(500) + 1001L);
     String[] opts =
         new String[] {
-          "ov", "nl", "imax", "hfr", "laser", "dolbycinema", "dolbyatmos", "3d", "4k", "4dx"
+          "ov",
+          "nl",
+          "imax",
+          "hfr",
+          "laser",
+          "dolbycinema",
+          "dolbyatmos",
+          "3d",
+          "4k",
+          "4dx",
+          "screenx"
         };
     for (String o : opts) {
       if (includeNulls && r.nextBoolean()) continue;

--- a/src/test/java/it/sijmen/movienotifier/service/pathe/pathe/PatheApiTest.java
+++ b/src/test/java/it/sijmen/movienotifier/service/pathe/pathe/PatheApiTest.java
@@ -1,8 +1,6 @@
 package it.sijmen.movienotifier.service.pathe.pathe;
 
-import static it.sijmen.movienotifier.model.FilterOption.NO;
-import static it.sijmen.movienotifier.model.FilterOption.NOPREFERENCE;
-import static it.sijmen.movienotifier.model.FilterOption.YES;
+import static it.sijmen.movienotifier.model.FilterOption.*;
 import static it.sijmen.movienotifier.model.serialization.UnixTimestampDeserializer.PATHEFORMAT;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -135,6 +133,7 @@ public class PatheApiTest {
                 + "            \"is4k\": 0,"
                 + "            \"isLaser\": 0,"
                 + "            \"is4dx\": false,"
+                + "            \"isScreenx\": false,"
                 + "            \"isVision\": false"
                 + "        }"
                 + "    ]"
@@ -164,6 +163,7 @@ public class PatheApiTest {
                     NO,
                     NO,
                     NO,
+                    NOPREFERENCE,
                     NOPREFERENCE,
                     NOPREFERENCE,
                     YES))));
@@ -197,6 +197,7 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 NO,
                 NOPREFERENCE,
+                NOPREFERENCE,
                 NOPREFERENCE));
 
     PatheShowing patheShowingResponse =
@@ -215,6 +216,7 @@ public class PatheApiTest {
             0,
             0,
             true,
+            false,
             false);
 
     assertFalse(api.accepts(watcher, patheShowingResponse));
@@ -245,6 +247,7 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 NOPREFERENCE,
                 NOPREFERENCE,
+                NOPREFERENCE,
                 NO,
                 NOPREFERENCE));
 
@@ -263,6 +266,7 @@ public class PatheApiTest {
             0,
             0,
             0,
+            false,
             false,
             true);
 
@@ -295,6 +299,7 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 NOPREFERENCE,
                 NOPREFERENCE,
+                NOPREFERENCE,
                 YES));
 
     PatheShowing patheShowingResponse =
@@ -312,6 +317,7 @@ public class PatheApiTest {
             0,
             0,
             0,
+            false,
             false,
             true);
 
@@ -344,6 +350,7 @@ public class PatheApiTest {
                 YES,
                 NOPREFERENCE,
                 NOPREFERENCE,
+                NOPREFERENCE,
                 NOPREFERENCE));
 
     PatheShowing patheShowingResponse =
@@ -362,6 +369,58 @@ public class PatheApiTest {
             0,
             0,
             false,
+            false,
+            false);
+
+    assertTrue(api.accepts(watcher, patheShowingResponse));
+  }
+
+  @Test
+  public void testISScreenX() throws ParseException {
+    PatheApi api =
+        spy(new PatheApi(new ObjectMapper(), "SOMEKEY", patheCacheRepository, notificationService));
+
+    Watcher watcher =
+        new Watcher(
+            "SOMEID",
+            "SOMEUSER",
+            "Star Wars 8 X",
+            21432,
+            1510992000185L,
+            1513186080310L,
+            new WatcherFilters(
+                12,
+                1513353540786L,
+                1513540800699L,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                YES,
+                NOPREFERENCE,
+                NOPREFERENCE));
+
+    PatheShowing patheShowingResponse =
+        new PatheShowing(
+            12,
+            21432,
+            2382115,
+            UnixTimestampDeserializer.PATHEFORMAT.parse("2017-12-15T21:00:00+01:00").getTime(),
+            UnixTimestampDeserializer.PATHEFORMAT.parse("2017-12-15T23:50:00+01:00").getTime(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            false,
+            true,
             false);
 
     assertTrue(api.accepts(watcher, patheShowingResponse));

--- a/src/test/java/it/sijmen/movienotifier/service/pathe/pathe/PatheApiTest.java
+++ b/src/test/java/it/sijmen/movienotifier/service/pathe/pathe/PatheApiTest.java
@@ -166,7 +166,8 @@ public class PatheApiTest {
                     NOPREFERENCE,
                     NOPREFERENCE,
                     NOPREFERENCE,
-                    YES))));
+                    YES,
+                    NOPREFERENCE))));
 
     verify(notificationService, times(fired ? 1 : 0)).sendUpdates(any(), any());
   }
@@ -196,6 +197,7 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 NOPREFERENCE,
                 NO,
+                NOPREFERENCE,
                 NOPREFERENCE,
                 NOPREFERENCE,
                 NOPREFERENCE));
@@ -249,6 +251,7 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 NOPREFERENCE,
                 NO,
+                NOPREFERENCE,
                 NOPREFERENCE));
 
     PatheShowing patheShowingResponse =
@@ -300,7 +303,8 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 NOPREFERENCE,
                 NOPREFERENCE,
-                YES));
+                YES,
+                NOPREFERENCE));
 
     PatheShowing patheShowingResponse =
         new PatheShowing(
@@ -348,6 +352,7 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 NOPREFERENCE,
                 YES,
+                NOPREFERENCE,
                 NOPREFERENCE,
                 NOPREFERENCE,
                 NOPREFERENCE,
@@ -402,6 +407,7 @@ public class PatheApiTest {
                 NOPREFERENCE,
                 YES,
                 NOPREFERENCE,
+                NOPREFERENCE,
                 NOPREFERENCE));
 
     PatheShowing patheShowingResponse =
@@ -422,6 +428,110 @@ public class PatheApiTest {
             false,
             true,
             false);
+
+    assertTrue(api.accepts(watcher, patheShowingResponse));
+  }
+
+  @Test
+  public void testISRegularShowing() throws ParseException {
+    PatheApi api =
+        spy(new PatheApi(new ObjectMapper(), "SOMEKEY", patheCacheRepository, notificationService));
+
+    Watcher watcher =
+        new Watcher(
+            "SOMEID",
+            "SOMEUSER",
+            "SOMENAME",
+            23469,
+            1564380000000L,
+            1564432200000L,
+            new WatcherFilters(
+                6,
+                1564840800000L,
+                1564866000000L,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                YES));
+
+    PatheShowing patheShowingResponse =
+        new PatheShowing(
+            6,
+            23469,
+            3098306,
+            UnixTimestampDeserializer.PATHEFORMAT.parse("2019-08-03T18:15:00+02:00").getTime(),
+            UnixTimestampDeserializer.PATHEFORMAT.parse("2019-08-03T20:46:00+02:00").getTime(),
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            false,
+            false,
+            false);
+
+    assertFalse(api.accepts(watcher, patheShowingResponse));
+  }
+
+  @Test
+  public void testISNoRegularShowing() throws ParseException {
+    PatheApi api =
+        spy(new PatheApi(new ObjectMapper(), "SOMEKEY", patheCacheRepository, notificationService));
+
+    Watcher watcher =
+        new Watcher(
+            "SOMEID",
+            "SOMEUSER",
+            "SOMENAME",
+            23469,
+            1564380000000L,
+            1564432200000L,
+            new WatcherFilters(
+                6,
+                1564840800000L,
+                1564866000000L,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NOPREFERENCE,
+                NO));
+
+    PatheShowing patheShowingResponse =
+        new PatheShowing(
+            6,
+            23469,
+            3098306,
+            UnixTimestampDeserializer.PATHEFORMAT.parse("2019-08-03T18:15:00+02:00").getTime(),
+            UnixTimestampDeserializer.PATHEFORMAT.parse("2019-08-03T20:46:00+02:00").getTime(),
+            1,
+            0,
+            0,
+            1,
+            0,
+            1,
+            0,
+            0,
+            false,
+            false,
+            true);
 
     assertTrue(api.accepts(watcher, patheShowingResponse));
   }


### PR DESCRIPTION
- Add a WatcherFilter for the upcoming ScreenX experience and the Pathe API as well as it already seems to provide this information.
- Add a WatcherFilter for 'regular' showings, which is showings not in any of the premium experiences currently offered (IMAX, Dolby Cinema, 4DX, ScreenX). This does not consider other variables such as room size, sound system or laser projection - just the format. This filter is helpful for filtering for any premium experience (regular `no`, others `nopreference`) or a selection of premium experience (for example IMAX and Dolby Cinema `nopreference`, regular and others `no`).